### PR TITLE
Make compatible with TYPO3 v12

### DIFF
--- a/Classes/Service/DinosaurService.php
+++ b/Classes/Service/DinosaurService.php
@@ -134,10 +134,8 @@ readonly class DinosaurService
             $queryBuilder->orderBy(self::NAME_FIELD);
         }
 
-        $queryBuilder->executeQuery();
-
         try {
-            return $queryBuilder->fetchAllAssociative();
+            return $queryBuilder->executeQuery()->fetchAllAssociative();
         } catch (Exception) {
             return [];
         }

--- a/Classes/Service/HashService.php
+++ b/Classes/Service/HashService.php
@@ -2,8 +2,10 @@
 
 namespace ErHaWeb\DinosaurFinder\Service;
 
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Crypto\HashService as CoreHashService;
+use TYPO3\CMS\Extbase\Security\Cryptography\HashService as ExtbaseHashService;
 
 class HashService
 {
@@ -11,8 +13,14 @@ class HashService
 
     public static function getHash(int $id): string
     {
-        if ($coreHashService = GeneralUtility::makeInstance(CoreHashService::class)) {
-            return $coreHashService->hmac($id, self::getSecret());
+        if ((new Typo3Version())->getMajorVersion() >= 13) {
+            if ($coreHashService = GeneralUtility::makeInstance(CoreHashService::class)) {
+                return $coreHashService->hmac($id, self::getSecret());
+            }
+        } else {
+            if ($extbaseHashService = GeneralUtility::makeInstance(ExtbaseHashService::class)) {
+                return $extbaseHashService->generateHmac($id);
+            }
         }
         return '';
     }


### PR DESCRIPTION
Hi @ErHaWeb!
First, thank you very much for this heplful extension :100: 
I encountered two issues when using the extension under TYPO3 v12:
1- Class "TYPO3\CMS\Core\Crypto\HashService" not found (in /var/www/html/packages/dinosaur_finder/Classes/Service/HashService.php line 14)
    https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-102763-ExtbaseHashService.html
2- Call to undefined method TYPO3\CMS\Core\Database\Query\QueryBuilder::fetchAllAssociative() (in /var/www/html/packages/dinosaur_finder/Classes/Service/DinosaurService.php line 140)
Could you please review my changes and adjust them gladly if necessary?